### PR TITLE
sd-bus: send explicit auth in the null-byte on FreeBSD/DragonFlyBSD

### DIFF
--- a/lib/initware/sd-bus/bus-internal.h
+++ b/lib/initware/sd-bus/bus-internal.h
@@ -207,6 +207,7 @@ struct sd_bus {
 	bool manual_peer_interface: 1;
 	bool is_system: 1;
 	bool is_user: 1;
+	bool send_null_byte: 1;
 
 	int use_memfd;
 


### PR DESCRIPTION
Based on: https://git.sr.ht/~emersion/basu/commit/503df0669c017afafe2e40e5a6a679f87e8c9067

---

Without doing this (and without modifying the D-Bus daemon to support passive credential gathering) nothing here can even connect to D-Bus.

---

I've also looked into adding basu support but all this code really likes things that basu doesn't expose, and even if I try to build the util file, there's still more stuff like `sd_bus_open_system_machine` that is in files that *are* built in basu but isn't present in basu, etc.